### PR TITLE
A simple token login prompt + fixed the token verifier

### DIFF
--- a/Naticord/API.cs
+++ b/Naticord/API.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -13,6 +14,7 @@ namespace Naticord
 {
     internal class API
     {
+        // Why do you need this? XD
         private static readonly HttpClient client = new HttpClient();
 
         public static async Task<string> SendAPI(string? token, string endpoint, HttpMethod method, object? data = null, byte[]? fileData = null, string? fileName = null)

--- a/Naticord/Client.cs
+++ b/Naticord/Client.cs
@@ -49,24 +49,20 @@ namespace Naticord
             try
             {
                 string response = await API.SendAPI(token, "users/@me", HttpMethod.Get, null);
-                var jsonResponse = JsonConvert.DeserializeObject<dynamic>(response);
-
-                if (jsonResponse?.message != null && jsonResponse.message.ToString().Contains("401: Unauthorized"))
-                {
-                    new CMessageBox("Your token is invalid.", "Don't worry, this shouldn't mean anything harmful. Naticord will sign you out for you to re-sign in and get a new token. You will have to reopen Naticord.").Show();
-                    Properties.Settings.Default.token = null;
-                    Properties.Settings.Default.Save();
-                    Application.Restart();
-                }
-                else
-                {
-                    Debug.WriteLine("Token is valid.");
-                }
             }
-            catch (JsonException ex)
+            catch (InvalidOperationException) // Request failed, thrown at API.cs:74
+            {
+                new CMessageBox("Your token is invalid.", "Don't worry, this shouldn't mean anything harmful. Naticord will sign you out for you to re-sign in and get a new token. You will have to reopen Naticord.").ShowDialog();
+                Properties.Settings.Default.token = null;
+                Properties.Settings.Default.Save();
+                Application.Restart();
+            }
+            catch (Exception ex)
             {
                 Debug.WriteLine($"Invalid response or error occurred: {ex.Message}");
+                Application.Exit();
             }
+            Debug.WriteLine("Token is valid.");
         }
 
         private async Task SetUserInfo()

--- a/Naticord/Login.Designer.cs
+++ b/Naticord/Login.Designer.cs
@@ -39,6 +39,9 @@
             this.label5 = new System.Windows.Forms.Label();
             this.linkLabel1 = new System.Windows.Forms.LinkLabel();
             this.welcomeBanner = new System.Windows.Forms.PictureBox();
+            this.orLabel = new System.Windows.Forms.Label();
+            this.tokenLabel = new System.Windows.Forms.Label();
+            this.tokenBox = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this.welcomeBanner)).BeginInit();
             this.SuspendLayout();
             // 
@@ -103,7 +106,7 @@
             // loginButton
             // 
             this.loginButton.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.loginButton.Location = new System.Drawing.Point(416, 290);
+            this.loginButton.Location = new System.Drawing.Point(416, 326);
             this.loginButton.Name = "loginButton";
             this.loginButton.Size = new System.Drawing.Size(72, 23);
             this.loginButton.TabIndex = 7;
@@ -127,7 +130,7 @@
             this.linkLabel1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.linkLabel1.LinkBehavior = System.Windows.Forms.LinkBehavior.NeverUnderline;
             this.linkLabel1.LinkColor = System.Drawing.Color.RoyalBlue;
-            this.linkLabel1.Location = new System.Drawing.Point(12, 294);
+            this.linkLabel1.Location = new System.Drawing.Point(12, 330);
             this.linkLabel1.Name = "linkLabel1";
             this.linkLabel1.Size = new System.Drawing.Size(82, 15);
             this.linkLabel1.TabIndex = 10;
@@ -145,20 +148,52 @@
             this.welcomeBanner.TabIndex = 0;
             this.welcomeBanner.TabStop = false;
             // 
+            // orLabel
+            // 
+            this.orLabel.AutoSize = true;
+            this.orLabel.Font = new System.Drawing.Font("Segoe UI", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.orLabel.Location = new System.Drawing.Point(250, 274);
+            this.orLabel.Name = "orLabel";
+            this.orLabel.Size = new System.Drawing.Size(30, 20);
+            this.orLabel.TabIndex = 1;
+            this.orLabel.Text = "OR";
+            // 
+            // tokenLabel
+            // 
+            this.tokenLabel.AutoSize = true;
+            this.tokenLabel.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tokenLabel.Location = new System.Drawing.Point(43, 300);
+            this.tokenLabel.Name = "tokenLabel";
+            this.tokenLabel.Size = new System.Drawing.Size(38, 15);
+            this.tokenLabel.TabIndex = 4;
+            this.tokenLabel.Text = "Token";
+            // 
+            // tokenBox
+            // 
+            this.tokenBox.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tokenBox.Location = new System.Drawing.Point(90, 297);
+            this.tokenBox.Name = "tokenBox";
+            this.tokenBox.Size = new System.Drawing.Size(377, 23);
+            this.tokenBox.TabIndex = 6;
+            this.tokenBox.UseSystemPasswordChar = true;
+            // 
             // Login
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(500, 323);
+            this.ClientSize = new System.Drawing.Size(500, 359);
             this.Controls.Add(this.linkLabel1);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.loginButton);
+            this.Controls.Add(this.tokenBox);
             this.Controls.Add(this.passwordBox);
+            this.Controls.Add(this.tokenLabel);
             this.Controls.Add(this.emailBox);
             this.Controls.Add(this.passwordLabel);
             this.Controls.Add(this.emailLabel);
             this.Controls.Add(this.welcomeHeader);
+            this.Controls.Add(this.orLabel);
             this.Controls.Add(this.welcomeLabel);
             this.Controls.Add(this.welcomeBanner);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
@@ -185,6 +220,9 @@
         private System.Windows.Forms.Button loginButton;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.LinkLabel linkLabel1;
+        private System.Windows.Forms.Label orLabel;
+        private System.Windows.Forms.Label tokenLabel;
+        private System.Windows.Forms.TextBox tokenBox;
     }
 }
 

--- a/Naticord/Login.cs
+++ b/Naticord/Login.cs
@@ -10,6 +10,7 @@ namespace Naticord
     {
         private string email;
         private string password;
+        private string token;
 
         public Login()
         {
@@ -20,9 +21,29 @@ namespace Naticord
 
         private void loginButton_Click(object sender, EventArgs e)
         {
-            email = emailBox.Text;
-            password = passwordBox.Text;
-            LoginToDiscord(email, password);
+            // The token box is prioritized
+            if (!string.IsNullOrEmpty(tokenBox.Text))
+            {
+                token = tokenBox.Text;
+                LoginToDiscordWithToken(token);
+            }
+            else
+            {
+                email = emailBox.Text;
+                password = passwordBox.Text;
+                LoginToDiscord(email, password);
+            }
+        }
+
+        // Could actually use overrides here I guess
+        public async void LoginToDiscordWithToken(string token)
+        {
+            Properties.Settings.Default.token = token;
+            Properties.Settings.Default.Save();
+            // Continues to the client
+            Client clientForm = new Client();
+            clientForm.Show();
+            this.Hide();
         }
 
         public async void LoginToDiscord(string email, string password)

--- a/Naticord/Naticord.csproj
+++ b/Naticord/Naticord.csproj
@@ -40,6 +40,9 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>


### PR DESCRIPTION
Added a token input field to the login screen + created a simple function to write the token directly, bypassing the auth endpoint.
Fixed an issue with `CheckIfTokenIsValid()` where an `InvalidOperationException` at `API.cs:74` was not being caught, leading to an unhandled exception.
And I've also changed the "Your token is invalid" message box from `Show()` to `ShowDialog()`, as it was closing immediately without letting the user read it.